### PR TITLE
Introduces command configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
             "cwd": "${workspaceRoot}/nrf-app",
             "preLaunchTask": "Cargo Build (debug)",
             "runToMain": true,
-            "executable": "./target/thumbv8m.main-none-eabihf/debug/thingy91-lorawan-nbiot",
+            "executable": "../target/thumbv8m.main-none-eabihf/debug/thingy91-lorawan-nbiot",
             "device": "nrf9160_xxaa",
             "svdFile": "${workspaceRoot}/.vscode/nrf9160.svd",
         }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ Running the app
 cargo run --target thumbv8m.main-none-eabihf
 ```
 
+Configuring the app
+---
+
+This application uses a special mode so that a user may configure it. We enter this special mode to 
+conserve battery by shutting down the UART when in regular running mode.
+
+To configure the app, you need to connect to the Thingy:91's serial port. You will also need to configure your
+serial port to add carriage returns to line feeds. `minicom` is a utility that easily enables this e.g. if
+the serial port is `/dev/tty.usbmodem143101`:
+
+```
+minicom -D /dev/tty.usbmodem143101
+```
+
+When connected to the serial port, hold down the Thingy:91's button during start up. This will place you into 
+"command mode". At any time, type "help" to see what can be done. Resetting the device exits command mode. Pressing
+the escape also causes the device to exit command mode and reset.
+
 Structure
 ---
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -15,7 +15,7 @@ use lorawan_encoding::keys;
 /// use app::EnvironmentalPayload;
 /// let bytes = app::data_up_unconfirmed(0, 0, &EnvironmentalPayload { temperature: 0, pressure: 1, humidity: 2, gas_resistance: 3 }, 0_u128, 0_u128);
 /// ```
-pub fn data_up_unconfirmed<'a>(
+pub fn data_up_unconfirmed(
     dev_addr: u32,
     fcnt: u32,
     payload: &EnvironmentalPayload,
@@ -37,7 +37,7 @@ pub fn data_up_unconfirmed<'a>(
         )
         .unwrap();
     let mut bytes = [0_u8; 27];
-    bytes.copy_from_slice(&bytes_ref);
+    bytes.copy_from_slice(bytes_ref);
     bytes
 }
 

--- a/memory.x
+++ b/memory.x
@@ -1,9 +1,12 @@
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  FLASH : ORIGIN = 0x00040000, LENGTH = 768K
+  FLASH : ORIGIN = 0x00040000, LENGTH = 764K
+  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 4K /* 4K is the flash page size */
   RAM : ORIGIN = 0x20020000, LENGTH = 128K
 }
+
+_config = ORIGIN(CONFIG);
 
 /* This is where the call stack will be allocated. */
 /* The stack is of the full descending type. */

--- a/nrf-app/Cargo.toml
+++ b/nrf-app/Cargo.toml
@@ -10,10 +10,17 @@ bme680 = "0.6"
 cortex-m = "0.7"
 cortex-m-rt = "0.6"
 embedded-hal = { version = "0.2", features = [ "unproven" ] }
+embedded-storage = "0.1.0"
+heapless = "0.7.6"
+menu = "0.3.2"
+nrf-hal-common = "0.13"
+nrf9160-hal = "0.13"
 nrfxlib = "0.6"
-thingy-91-nrf9160-bsp = { git = "https://github.com/titanclass/thingy-91-nrf9160.git", branch = "master" }
 panic-reset = "0.1"
 panic-halt = "0.2"
+postcard = "0.7.0"
+serde = { version = "1.0.126", default-features = false }
+thingy-91-nrf9160-bsp = { git = "https://github.com/titanclass/thingy-91-nrf9160.git", branch = "master" }
 tinyrlibc = "0.2"
 
 app = { path = "../app" }

--- a/nrf-app/src/command.rs
+++ b/nrf-app/src/command.rs
@@ -1,0 +1,360 @@
+use bsp::hal::{uarte::Instance, Timer, Uarte};
+use core::fmt::Write;
+use menu::{Item, ItemType, Menu, Parameter, Runner};
+use nrf9160_hal::pac::NVMC_NS;
+use nrf_hal_common::{nvmc::Nvmc, pac::TIMER0_NS};
+use thingy_91_nrf9160_bsp::hal::uarte;
+
+use crate::config::Config;
+
+pub struct Console<'a, T>
+where
+    T: Instance,
+{
+    config: &'a mut Config,
+    nvmc: &'a mut Nvmc<NVMC_NS>,
+    timer: &'a mut Timer<TIMER0_NS>,
+    uarte: &'a mut Uarte<T>,
+}
+
+impl<'a, T> Console<'a, T>
+where
+    T: Instance,
+{
+    pub fn with(
+        config: &'a mut Config,
+        nvmc: &'a mut Nvmc<NVMC_NS>,
+        timer: &'a mut Timer<TIMER0_NS>,
+        uarte: &'a mut Uarte<T>,
+    ) -> Self {
+        Console {
+            config,
+            nvmc,
+            timer,
+            uarte,
+        }
+    }
+}
+
+impl<'a, T> Write for Console<'a, T>
+where
+    T: Instance,
+{
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.uarte.write_str(s)
+    }
+}
+
+fn set_net_id<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    match u32::from_str_radix(args[0].trim_start_matches("0x"), 16) {
+        Ok(v) => context.config.net_id = v,
+        Err(_) => writeln!(context, "Invalid").unwrap(),
+    };
+}
+
+fn set_nwk_skey<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    match (
+        u128::from_str_radix(args[0].trim_start_matches("0x"), 16),
+        args[0].len() == 32,
+    ) {
+        (Ok(v), true) => context.config.nwkskey = Some(v),
+        _ => writeln!(context, "Invalid").unwrap(),
+    };
+}
+
+fn set_app_skey<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    match (
+        u128::from_str_radix(args[0].trim_start_matches("0x"), 16),
+        args[0].len() == 32,
+    ) {
+        (Ok(v), true) => context.config.appskey = Some(v),
+        _ => writeln!(context, "Invalid").unwrap(),
+    };
+}
+
+fn set_iccid<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    match args[0].parse::<u64>() {
+        Ok(v) => context.config.iccid = Some(v),
+        Err(_) => writeln!(context, "Invalid").unwrap(),
+    };
+}
+
+fn set_send_freq_ms<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    match args[0].parse::<u32>() {
+        Ok(v) => context.config.send_frequency_ms = v,
+        Err(_) => writeln!(context, "Invalid").unwrap(),
+    };
+}
+
+fn set_network_server_host<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    let mut iter = args[0].split('.');
+    let mut result = [None; 4];
+    for r in &mut result {
+        if let Some(v) = iter.next() {
+            if let Ok(v) = v.parse::<u8>() {
+                *r = Some(v);
+            }
+        } else {
+            break;
+        }
+    }
+    match result {
+        [Some(b0), Some(b1), Some(b2), Some(b3)] => {
+            context.config.network_server_host = Some([b0, b1, b2, b3]);
+        }
+        _ => writeln!(context, "Invalid").unwrap(),
+    }
+}
+
+fn set_network_server_port<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    match args[0].parse::<u16>() {
+        Ok(v) => context.config.network_server_port = v,
+        Err(_) => writeln!(context, "Invalid").unwrap(),
+    };
+}
+
+fn save<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    _args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    write!(context, "Saving to flash... ").unwrap();
+    match context.config.save(&mut context.nvmc) {
+        Ok(_) => writeln!(context, "saved.").unwrap(),
+        Err(_) => writeln!(context, "there was a problem saving.").unwrap(),
+    };
+}
+
+fn show<'a, T>(
+    _menu: &Menu<Console<'a, T>>,
+    _item: &Item<Console<'a, T>>,
+    _args: &[&str],
+    context: &mut Console<'a, T>,
+) where
+    T: Instance,
+{
+    let config = context.config.clone();
+    writeln!(context, "Settings...\n").unwrap();
+    writeln!(context, "NET_ID:\t\t\t 0x{:08X}", config.net_id).unwrap();
+    if let Some(nwkskey) = config.nwkskey {
+        writeln!(context, "NWKSKEY:\t\t 0x{:032X}", nwkskey).unwrap();
+    } else {
+        writeln!(context, "NWKSKEY:\t\t REQUIRED!").unwrap();
+    }
+    if let Some(appskey) = config.appskey {
+        writeln!(context, "APPSKEY:\t\t 0x{:032X}", appskey).unwrap();
+    } else {
+        writeln!(context, "APPSKEY:\t\t REQUIRED!").unwrap();
+    }
+    if let Some(iccid) = config.iccid {
+        writeln!(context, "ICCID:\t\t\t {}", iccid).unwrap();
+    } else {
+        writeln!(context, "ICCID:\t\t\t REQUIRED!").unwrap();
+    }
+    writeln!(context, "SEND_FREQUENCY_MS:\t {}", config.send_frequency_ms).unwrap();
+    if let Some(network_server_host) = config.network_server_host {
+        writeln!(
+            context,
+            "NETWORK_SERVER_HOST:\t {}.{}.{}.{}",
+            network_server_host[0],
+            network_server_host[1],
+            network_server_host[2],
+            network_server_host[3]
+        )
+        .unwrap();
+    } else {
+        writeln!(context, "NETWORK_SERVER_HOST:\t REQUIRED!").unwrap();
+    }
+    writeln!(
+        context,
+        "NETWORK_SERVER_PORT:\t {}",
+        config.network_server_port
+    )
+    .unwrap();
+}
+
+pub fn enter<T>(console: Console<T>)
+where
+    T: Instance,
+{
+    let menu = Menu {
+        label: "root",
+        items: &[
+            &Item {
+                item_type: ItemType::Callback {
+                    function: set_net_id,
+                    parameters: &[Parameter::Optional {
+                        parameter_name: "NET_ID",
+                        help: Some(
+                            "The Network ID in hex form. Defaults to \"0x13\" for The Things Network",
+                        ),
+                    }],
+                },
+                command: "set-net-id",
+                help: Some("Sets a LoRaWAN Network ID"),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: set_nwk_skey,
+                    parameters: &[Parameter::Mandatory {
+                        parameter_name: "NWKSKEY",
+                        help: Some("e.g. EE508F76B0492985BFACBACE0B2754C2"),
+                    }],
+                },
+                command: "set-nwkskey",
+                help: Some("Sets a LoRaWAN Network Session Key in hex form"),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: set_app_skey,
+                    parameters: &[Parameter::Mandatory {
+                        parameter_name: "APPSKEY",
+                        help: Some("e.g. BA357A0A743BD19BD4509B9667C87658"),
+                    }],
+                },
+                command: "set-appskey",
+                help: Some("Sets a LoRaWAN Application Session Key in hex form"),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: set_iccid,
+                    parameters: &[Parameter::Mandatory {
+                        parameter_name: "ICCID",
+                        help: Some("e.g. 923453256784434561 i.e. without the country code!"),
+                    }],
+                },
+                command: "set-iccid",
+                help: Some("Sets the device's ICCID"),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: set_send_freq_ms,
+                    parameters: &[Parameter::Optional {
+                        parameter_name: "SEND_FREQUENCY_MS",
+                        help: Some("Defaults to 60 * 60 * 1000 (1 hour)"),
+                    }],
+                },
+                command: "set-send-freq",
+                help: Some("Sets the data transmission frequency to flash. Defaults to 3600000ms."),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: set_network_server_host,
+                    parameters: &[Parameter::Mandatory {
+                        parameter_name: "NETWORK_SERVER_HOST",
+                        help: Some("The IP V4 address of the host"),
+                    }],
+                },
+                command: "set-network-host",
+                help: Some("Sets the network server host."),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: set_network_server_port,
+                    parameters: &[Parameter::Optional {
+                        parameter_name: "NETWORK_SERVER_PORT",
+                        help: Some("The IP port of the host. Defaults to 1694."),
+                    }],
+                },
+                command: "set-network-port",
+                help: Some("Sets the network server port."),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: save,
+                    parameters: &[],
+                },
+                command: "save",
+                help: Some("Saves settings to flash."),
+            },
+            &Item {
+                item_type: ItemType::Callback {
+                    function: show,
+                    parameters: &[],
+                },
+                command: "show",
+                help: Some("Shows settings."),
+            },
+        ],
+        entry: None,
+        exit: None,
+    };
+
+    let mut buffer = [0u8; 64];
+    let mut r = Runner::new(&menu, &mut buffer, console);
+    loop {
+        let mut rx_buffer = [0u8; 64];
+        let rx_buffer = match r
+                .context
+                .uarte
+                .read_timeout(&mut rx_buffer, r.context.timer, 100_000) // Tenth of a second delay given the a 1hz prescaler so we can catch many chars
+            {
+                Ok(_) => &rx_buffer,
+                Err(uarte::Error::Timeout(n)) => &rx_buffer[0..n],
+                _ => break,
+            };
+        for b in rx_buffer {
+            match *b {
+                b if b as char == '\x1b' => {
+                    break;
+                }
+                b if b as char == '\n' => {
+                    r.input_byte(b'\r');
+                }
+                b => r.input_byte(b),
+            }
+        }
+    }
+}

--- a/nrf-app/src/config.rs
+++ b/nrf-app/src/config.rs
@@ -1,0 +1,87 @@
+///! Configuration is provided such that it has a stable representation
+///! for both in-memory storage per flash memory, and when communicated
+///! between devices, perhaps over serial communications. The goal is to
+///! use one form of serialisation and the method adopted uses Postcard
+///! given its generality.
+///! In particular, I wish to consider a future capability of bulk-flashing
+///! configuration to devices during their manufacturing.
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+use nrf_hal_common::{nvmc::Nvmc, pac::NVMC_NS};
+use postcard::{from_bytes, to_slice};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
+#[repr(u32)]
+pub enum Version {
+    V1 = 1,
+    Invalid = 0xffffffff, // Represents erased flash memory
+}
+
+pub type Ipv4Addr = [u8; 4];
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Config {
+    pub version: Version,
+    pub net_id: u32,
+    pub nwkskey: Option<u128>,
+    pub appskey: Option<u128>,
+    pub iccid: Option<u64>,
+    pub send_frequency_ms: u32,
+    pub network_server_host: Option<Ipv4Addr>,
+    pub network_server_port: u16,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config {
+            version: Version::V1,
+            net_id: 0x13_u32,
+            nwkskey: None,
+            appskey: None,
+            iccid: None,
+            send_frequency_ms: 60 * 60 * 1000, // 1 hour
+            network_server_host: None,
+            network_server_port: 1694,
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.nwkskey.is_some()
+            && self.appskey.is_some()
+            && self.iccid.is_some()
+            && self.network_server_host.is_some()
+    }
+
+    pub fn load(nvmc: &mut Nvmc<NVMC_NS>) -> Result<Self, ConfigError> {
+        let mut buf = [0u8; 64];
+        match nvmc.try_read(0, &mut buf) {
+            Ok(_) => match from_bytes::<Self>(&buf) {
+                Ok(c) if c.version != Version::Invalid => Ok(c),
+                _ => Ok(Self::new()),
+            },
+            Err(_) => Err(ConfigError::CannotLoad),
+        }
+    }
+
+    pub fn save(&self, nvmc: &mut Nvmc<NVMC_NS>) -> Result<(), ConfigError> {
+        let mut buf = [0u8; 64];
+        match to_slice(&self, &mut buf) {
+            Ok(_) => nvmc
+                .try_erase(0, 4096)
+                .and_then(|_| nvmc.try_write(0, &buf))
+                .map_err(|_| ConfigError::CannotSave),
+            Err(_) => Err(ConfigError::CannotSave),
+        }
+    }
+}
+
+pub enum ConfigError {
+    CannotLoad,
+    CannotSave,
+}
+
+impl<'a> Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
The nice "menu" library is used to provide a friendly experience for configuring the device. For example, typing "help" when in command mode will describe the commands that can be used.

Command mode on the UART is entered by holding down the Thingy:91's button when powered up (or somehow reset). Command mode can be exited by simply resetting the device or pressing the escape key - which will then reset. Command mode is also entered into if the flash area is uninitialized.

We have this special mode for configuration so that we can disable the UART for regular running, which in turn saves power.

This functionality appears to add around 10KiB to the firmware (unsure how much the UART code itself is adding at this point, and I've not checked this for a while - could even now be 15KiB), but I think it is worth it given the nice user experience. For more device-constrained things, I would probably use a simple AT command-style approach. However, devices generally have enough mem for this sort of thing. I've seen other devices offer both the friendly approach like this and the AT command style.